### PR TITLE
Enforce Maild startup verificationt to ignore XML comments

### DIFF
--- a/src/init/wazuh-server.sh
+++ b/src/init/wazuh-server.sh
@@ -298,7 +298,7 @@ start_service()
     for i in ${SDAEMONS}; do
         ## If wazuh-maild is disabled, don't try to start it.
         if [ X"$i" = "Xwazuh-maild" ]; then
-             grep "<email_notification>no<" ${DIR}/etc/ossec.conf >/dev/null 2>&1
+             grep "<email_notification>no<" ${DIR}/etc/ossec.conf | grep -v '<!--' >/dev/null 2>&1
              if [ $? = 0 ]; then
                  continue
              fi


### PR DESCRIPTION
## Description

Hello Team,

When a user add an xml comment to keep track of the configuration changes similar to `<!-- OLD (changed by elwali.karkoub) <email_notification>no</email_notification> -->` it does not allow the maild to startup while the email_notification is set to `yes`. It is caused by how the Wazuh control verify the configuration: 

Current Behavior:


![notstartedmaild](https://github.com/user-attachments/assets/ed660663-51e0-4598-8582-55c874bd8c3e)


The fix: consists of a simple exclusion of the XML comment.

![FIXmaildstartup](https://github.com/user-attachments/assets/fbd9bf02-81e6-4fa8-be36-885d8ff93c81)



